### PR TITLE
[Bots] bot command mez spell list fix

### DIFF
--- a/zone/bot_command.cpp
+++ b/zone/bot_command.cpp
@@ -281,7 +281,7 @@ public:
 						entry_prototype->SafeCastToInvisibility()->invis_type = BCEnum::IT_Animal;
 						break;
 					case SE_Mez:
-						if (spells[spell_id].spell_affect_index != 12)
+						if (spells[spell_id].effect_id[EFFECTIDTOINDEX(1)] != 31)
 							break;
 						entry_prototype = new STBaseEntry(BCEnum::SpT_Mesmerize);
 						break;


### PR DESCRIPTION
Mez spell list was using spell affect index =12 to identify mez spells but this does not include necro mez. Changed to effect index 1 =31, as all player cast mez spells have the mez effect in this slot.